### PR TITLE
gitignore:node-modules, env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,9 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+#node.js
+node_modules/
+
+#environment variables
+.env


### PR DESCRIPTION
node_modules, and most importantly .env should never be in your repo, as it contains sensitive info.

added to .gitignore

Once accidentally pushed my .env at work and had to delete my entire branch, pull request lol

-Jacob